### PR TITLE
chore:Se añade plugin de prettier para ordenar css

### DIFF
--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -9,4 +9,5 @@ export default {
 	arrowParens: 'avoid',
     jsxSingleQuote: true,
     endOfLine: 'auto',
+	plugins: ["prettier-plugin-css-order",],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,9 @@
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "postcss": "^8.4.39",
         "prettier": "^3.3.3",
+        "prettier-plugin-css-order": "^2.1.2",
         "prettier-plugin-organize-imports": "^4.0.0",
         "typescript": "^5.2.2",
         "vite": "^5.3.1"
@@ -1694,6 +1696,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-declaration-sorter": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
       }
     },
     "node_modules/csstype": {
@@ -4222,6 +4236,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4256,6 +4308,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-css-order": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-css-order/-/prettier-plugin-css-order-2.1.2.tgz",
+      "integrity": "sha512-vomxPjHI6pOMYcBuouSJHxxQClJXaUpU9rsV9IAO2wrSTZILRRlrxAAR8t9UF6wtczLkLfNRFUwM+ZbGXOONUA==",
+      "dev": true,
+      "dependencies": {
+        "css-declaration-sorter": "^7.1.1",
+        "postcss-less": "^6.0.0",
+        "postcss-scss": "^4.0.9"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "prettier": "3.x"
       }
     },
     "node_modules/prettier-plugin-organize-imports": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "postcss": "^8.4.39",
     "prettier": "^3.3.3",
+    "prettier-plugin-css-order": "^2.1.2",
     "prettier-plugin-organize-imports": "^4.0.0",
     "typescript": "^5.2.2",
     "vite": "^5.3.1"


### PR DESCRIPTION
Resumen:
Se añade un plugin de Prettier para ordenar propiedades CSS automáticamente.

Motivación y contexto:
Mejorar la legibilidad y consistencia del código CSS en el proyecto.

Cambios realizados:

Instalación y configuración del plugin de Prettier para ordenar propiedades CSS.