### PR TITLE
feat: Implementación de servicio para crear Specifications y sus interfaces y se quita capitalización en familias al guardar

### DIFF
--- a/src/components/CreateSpecs.tsx
+++ b/src/components/CreateSpecs.tsx
@@ -1,5 +1,6 @@
 import { SpecsFrontend } from '@adapters/specifications.adapter';
 import '@components/css/createSpecs.css';
+import createSpecification from '@services/specifications/createSpecification.service';
 import { useEffect, useState } from 'react';
 function CreateSpecs({
 	familyId,
@@ -18,7 +19,7 @@ function CreateSpecs({
 				name: '',
 				description: '',
 				unit: '',
-				createdBy: '',
+				createdBy: 'El usuario',
 				path: '',
 				familyId,
 				categoryId,
@@ -36,7 +37,7 @@ function CreateSpecs({
 				name: '',
 				description: '',
 				unit: '',
-				createdBy: '',
+				createdBy: 'El usuario',
 				path: '',
 				familyId,
 				categoryId,
@@ -62,16 +63,20 @@ function CreateSpecs({
 		setSpecifications(newspecifications);
 	};
 
-	const saveSpecifications = () => {
+	const saveSpecifications = async () => {
 		// Usar SpecsMappingBack
 		const datos = {
 			familyId,
 			categoryId,
 			subcategoryId,
 			specifications,
+			createdBy: 'El usuario',
 		};
 		console.log(JSON.stringify(datos));
 		alert('Especificaciones guardadas. Revisa la consola para ver los datos.');
+		for (const specification of specifications) {
+			await createSpecification({ specification });
+		}
 	};
 	return (
 		<div id='specifications'>

--- a/src/hooks/useFamilyManagement.ts
+++ b/src/hooks/useFamilyManagement.ts
@@ -34,10 +34,9 @@ const useFamilyManagement = () => {
 	};
 	const handleDelete = async (familyid: string, familyname: string) => {
 		try {
-			await axios.delete(
-        import.meta.env.VITE_API_URL + `/families/${familyid}`,
-        )
-        .then(
+			await axios
+				.delete(import.meta.env.VITE_API_URL + `/families/${familyid}`)
+				.then(
 					await axios.delete(
 						import.meta.env.VITE_API_URL + `/categories/family/${familyid}`,
 					),

--- a/src/interfaces/Specifications.interface.ts
+++ b/src/interfaces/Specifications.interface.ts
@@ -1,0 +1,11 @@
+export interface Specification {
+	name: string;
+	description?: string;
+	units?: string;
+	familyId: string;
+	categoryId: string;
+	subcategoryId?: string;
+	createdBy?: string;
+	updatedBy?: string;
+}
+export interface SpecificationSuccesResponse {}

--- a/src/pages/specificationsPages/CreateFamily.tsx
+++ b/src/pages/specificationsPages/CreateFamily.tsx
@@ -18,26 +18,6 @@ interface SubcategoryAux {
 	categoryIndex: number;
 	subcategory: SubcategoryFrontend;
 }
-
-function capitalizeCategoryNames(category: CategoryFrontend) {
-	const capitalizedCategory: CategoryFrontend = {
-		name: '',
-		description: '',
-		createdBy: '',
-		path: '',
-		familyId: '',
-	};
-	for (const key in category) {
-		if (Object.prototype.hasOwnProperty.call(category, key)) {
-			if (key === 'name') {
-				capitalizedCategory[key] = category[key].toLowerCase();
-				console.log(capitalizedCategory[key]);
-			}
-		}
-	}
-	return capitalizedCategory;
-}
-
 function CreateFamilyForm() {
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
@@ -52,7 +32,7 @@ function CreateFamilyForm() {
 	const handleSubmit = async (e: { preventDefault: () => void }) => {
 		e.preventDefault();
 		await createFamily({
-			name: name.toLowerCase(),
+			name,
 			description,
 			createdBy,
 			path: '',
@@ -61,7 +41,7 @@ function CreateFamilyForm() {
 				console.log('Family ID:', familyId);
 				const createdCategoryPromises = categories.map(async category => {
 					return await createCategory({
-						...capitalizeCategoryNames(category),
+						...category,
 						familyId,
 						createdBy,
 					});

--- a/src/services/specifications/createSpecification.service.ts
+++ b/src/services/specifications/createSpecification.service.ts
@@ -1,0 +1,23 @@
+import {
+	Specification,
+	SpecificationSuccesResponse,
+} from '@interfaces/Specifications.interface';
+import axios from 'axios';
+
+export default async function createSpecification({
+	specification,
+}: {
+	specification: Specification;
+}) {
+	try {
+		const response = await axios.post<SpecificationSuccesResponse>(
+			import.meta.env.VITE_API_URL + '/specifications',
+			specification,
+		);
+		const specificationCreated = response.data;
+		console.log('Especificación creado con éxito');
+		return specificationCreated;
+	} catch (error) {
+		console.error(error);
+	}
+}


### PR DESCRIPTION
Se implementa un servicio para crear especificaciones y se añaden las interfaces correspondientes. Además, se quita la capitalización automática en el nombre de familias al guardarlas.

Motivación y contexto:
Mejorar la funcionalidad y consistencia en la creación de especificaciones y en el manejo de datos de familias.

Cambios realizados:

Implementación de un servicio para la creación de especificaciones.
Creación de interfaces relacionadas con las especificaciones.
Eliminación de la capitalización automática en el nombre de familias al guardarlas.